### PR TITLE
Fix links broken around RGB Core, RGB STD and RGB CLI

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -5,5 +5,5 @@ by [LNP/BP Standards Association](https://lnp-bp.org). You can read more about R
 - Standards defining RGB are part of [LNPBP standards](https://github.com/LNP-BP/LNPBPs)
 - Reference implementation of consensus/validation code is [RGB Core Lib](https://github.com/RGB-WG/rgb-core)
 - High-level API to RGB contracts is provided by [RGB Standard Lib](https://github.com/RGB-WG/rgb-std)
-- To run RGB, you can use [RGB](/RGB-WG/rgb) command-line tool. Alternatively, you can 
+- To run RGB, you can use [RGB](https://github.com/RGB-WG/rgb) command-line tool. Alternatively, you can 
   other existing software listed here: <https://rgb.tech/install/>.

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,6 +4,6 @@ by [LNP/BP Standards Association](https://lnp-bp.org). You can read more about R
 
 - Standards defining RGB are part of [LNPBP standards](https://github.com/LNP-BP/LNPBPs)
 - Reference implementation of consensus/validation code is [RGB Core Lib](https://github.com/RGB-WG/rgb-core)
-- High-level API to RGB contracts is provided by [RGB Standard Lib](/RGB-WG/rgb-std)
+- High-level API to RGB contracts is provided by [RGB Standard Lib](https://github.com/RGB-WG/rgb-std)
 - To run RGB, you can use [RGB](/RGB-WG/rgb) command-line tool. Alternatively, you can 
   other existing software listed here: <https://rgb.tech/install/>.

--- a/profile/README.md
+++ b/profile/README.md
@@ -3,7 +3,7 @@ by [LNP/BP Standards Association](https://lnp-bp.org). You can read more about R
 [our official site](https://rgb.tech) and in [FAQ](https://rgbfaq.com).
 
 - Standards defining RGB are part of [LNPBP standards](https://github.com/LNP-BP/LNPBPs)
-- Reference implementation of consensus/validation code is [RGB Core Lib](/RGB-WG/rgb-core)
+- Reference implementation of consensus/validation code is [RGB Core Lib](https://github.com/RGB-WG/rgb-core)
 - High-level API to RGB contracts is provided by [RGB Standard Lib](/RGB-WG/rgb-std)
 - To run RGB, you can use [RGB](/RGB-WG/rgb) command-line tool. Alternatively, you can 
   other existing software listed here: <https://rgb.tech/install/>.


### PR DESCRIPTION
When the user clicks on the README link, it is not taking them to the repository

![image](https://github.com/RGB-WG/.github/assets/83122757/0b272e4d-9060-491b-a7e9-3ed7e5a99b3c)
